### PR TITLE
Better support for MariaDB and MySQL

### DIFF
--- a/django_apscheduler/jobstores.py
+++ b/django_apscheduler/jobstores.py
@@ -207,9 +207,7 @@ class DjangoJobStore(DjangoResultStoreMixin, BaseJobStore):
         # Acquire lock for update
         with transaction.atomic():
             try:
-                db_job = DjangoJob.objects.select_for_update(of=("self",)).get(
-                    id=job.id
-                )
+                db_job = DjangoJob.objects.get(id=job.id)
 
                 db_job.next_run_time = get_django_internal_datetime(job.next_run_time)
                 db_job.job_state = pickle.dumps(

--- a/django_apscheduler/models.py
+++ b/django_apscheduler/models.py
@@ -153,9 +153,9 @@ class DjangoJobExecution(models.Model):
 
             try:
                 with transaction.atomic():
-                    job_execution = DjangoJobExecution.objects.select_for_update(
-                        of=("self",)
-                    ).get(job_id=job_id, run_time=run_time)
+                    job_execution = DjangoJobExecution.objects.select_for_update().get(
+                        job_id=job_id, run_time=run_time
+                    )
 
                     if status == DjangoJobExecution.SENT:
                         # Ignore 'submission' events for existing job executions. APScheduler does not appear to

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,14 @@
 
 This changelog is used to track all major changes to django_apscheduler.
 
+
+## v0.4.1 (UNRELEASED)
+
+**Fixes**
+
+- Drop use of `of` parameter in `select_for_update`, which is not supported by MariaDB and MySQL (Fixes [#94](https://github.com/jarekwg/django-apscheduler/issues/94)).
+
+
 ## v0.4.0 (2020-07-27)
 
 **Enhancements**


### PR DESCRIPTION
Drop use of `of` parameter in `select_for_update`, which is [not supported](https://docs.djangoproject.com/en/3.0/ref/databases/#row-locking-with-queryset-select-for-update) by MariaDB and MySQL.

Fixes #94.