### PR TITLE
Deprecate @register_job decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,6 @@ class Command(BaseCommand):
 - Register any APScheduler jobs as you would normally. Note that if you haven't set `DjangoJobStore` as the `'default'`
   job store, then you will need to include `jobstore='djangojobstore'` in your `scheduler.add_job` calls.
 
-- One can also use APScheduler's decorator version of [`add_job()`](https://apscheduler.readthedocs.io/en/latest/modules/schedulers/base.html#apscheduler.schedulers.base.BaseScheduler.add_job"apscheduler.schedulers.base.BaseScheduler.add_job") - [`@scheduler.scheduled_job`](https://apscheduler.readthedocs.io/en/latest/modules/schedulers/base.html#apscheduler.schedulers.base.BaseScheduler.scheduled_job) to register a job,e.g. 
-```python
-@scheduler.scheduled_job("cron", hour=5, minute=0, second=10, max_instances=1, id='YourJobId')# run at 5：99：10 everyday
-def job():
-    pass
-```
-
 - All of the jobs that have been scheduled are viewable directly in the Django admin interface.
 
 - django_apscheduler will create a log of all job executions and their associated APScheduler status that can also be

--- a/README.md
+++ b/README.md
@@ -133,11 +133,9 @@ class Command(BaseCommand):
 - Register any APScheduler jobs as you would normally. Note that if you haven't set `DjangoJobStore` as the `'default'`
   job store, then you will need to include `jobstore='djangojobstore'` in your `scheduler.add_job` calls.
 
-- django-apscheduler also provides a custom `@register_job` decorator for job registration. This is similar to
-  APScheduler's `@scheduler.scheduled_job`, except that it automatically assigns a unique job `id` based on the Python
-  module and function name:
+- One can also use APScheduler's decorator version of [`add_job()`](https://apscheduler.readthedocs.io/en/latest/modules/schedulers/base.html#apscheduler.schedulers.base.BaseScheduler.add_job"apscheduler.schedulers.base.BaseScheduler.add_job") - [`@scheduler.scheduled_job`](https://apscheduler.readthedocs.io/en/latest/modules/schedulers/base.html#apscheduler.schedulers.base.BaseScheduler.scheduled_job) to register a job,e.g. 
 ```python
-@register_job(scheduler, "interval", seconds=60)
+@scheduler.scheduled_job("cron", hour=5, minute=0, second=10, max_instances=1, id='YourJobId')# run at 5：99：10 everyday
 def job():
     pass
 ```

--- a/django_apscheduler/jobstores.py
+++ b/django_apscheduler/jobstores.py
@@ -299,7 +299,7 @@ class DjangoMemoryJobStore(DjangoResultStoreMixin, MemoryJobStore):
 
 
 def register_events(scheduler, result_storage=None):
-    # TODO: Remove this deprecated function in release 0.5
+    # TODO: Remove this deprecated function in release 1.0
     # DjangoResultStoreMixin now takes care of registering event listeners automatically when the scheduler is started.
     warnings.warn(
         "'register_events' is deprecated since version 0.4.0. Please remove all references from your code.",
@@ -326,6 +326,13 @@ def register_job(scheduler: BaseScheduler, *args, **kwargs) -> callable:
     """
 
     def wrapper_register_job(func):
+        # TODO: Remove this deprecated function in release 1.0
+        warnings.warn(
+            "The 'register_job' decorator is deprecated since version 0.5.0. Please use APScheduler's add_job() method "
+            "or @scheduled_job decorator instead.",
+            DeprecationWarning,
+        )
+
         kwargs.setdefault("id", f"{func.__module__}.{func.__name__}")
         scheduler.add_job(func, *args, **kwargs)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,8 @@ This changelog is used to track all major changes to django_apscheduler.
 **Enhancements**
 
 - Add ability to trigger a scheduled job manually from the `DjangoJobAdmin` page (Resolves [#102](https://github.com/jarekwg/django-apscheduler/issues/102)).
+- The @register_job decorator has been deprecated. Please use APScheduler's add_job() method or @scheduled_job
+  decorator instead (thanks to @redstoneleo).
 
 **Fixes**
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,7 +9,7 @@ This changelog is used to track all major changes to django_apscheduler.
 
 - Add ability to trigger a scheduled job manually from the `DjangoJobAdmin` page (Resolves [#102](https://github.com/jarekwg/django-apscheduler/issues/102)).
 - The @register_job decorator has been deprecated. Please use APScheduler's add_job() method or @scheduled_job
-  decorator instead (thanks to @redstoneleo).
+  decorator instead (Resolves [#119](https://github.com/jarekwg/django-apscheduler/pull/119)).
 
 **Fixes**
 

--- a/tests/test_jobstores.py
+++ b/tests/test_jobstores.py
@@ -157,3 +157,14 @@ def test_register_job(scheduler, jobstore):
     scheduler.start()
 
     assert DjangoJob.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_register_job_raises_deprecation_warning(scheduler, jobstore):
+
+    with warnings.catch_warnings(record=True) as w:
+
+        register_job(scheduler, "interval", seconds=1)(dummy_job)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, DeprecationWarning)
+        assert "deprecated" in str(w[-1].message)


### PR DESCRIPTION
See: https://github.com/jarekwg/django-apscheduler/pull/119