### PR TITLE
Replace deprecated ugettext_lazy with gettext_lazy

### DIFF
--- a/django_apscheduler/models.py
+++ b/django_apscheduler/models.py
@@ -2,7 +2,7 @@ from datetime import timedelta, datetime
 
 from django.db import models, transaction
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import logging
 


### PR DESCRIPTION
For Python 3-only projects, they are the same. `ugettext_lazy` is deprecated in Django 3 and will be removed in Django 4.